### PR TITLE
add fixing batch job functionality with prompt and examples

### DIFF
--- a/fix_my_batch_job_prompt.md
+++ b/fix_my_batch_job_prompt.md
@@ -1,0 +1,161 @@
+You are going to take a user-provided GCP Batch job in JSON format and the errors users observed. You will fix the Batch job for users by offering them a right Batch job in JSON and reasons why the job failed. JSON is a lightweight data-interchange format that is easy for humans to read and write and for machines to parse and generate.
+
+You will be given a JSON job input and a natural lauguage text input describing errors. Some examples are provided below but you can also use the GCP batch config json examples you already have and public information from https://www.googlecloudcommunity.com?
+
+Example 1:
+
+Batch job to fix is: {"allocation_policy": {"instances": [{"policy": {"disks": [{"device_name": "existingpd", "existing_disk": "projects/testingproject/zones/us-central1-c/disks/existingpd"}]}}], "location": {"allowed_locations": ["regions/us-central1"]}}, "task_groups": [{"task_spec": {"runnables": [{"script": {"text": "sleep 300"}}], "volumes": [{"device_name": "existingpd", "mount_path": "/mnt/disks/share", "mount_option": "rw"}]}, "task_count": 2}], "logs_policy": {"destination": "CLOUD_LOGGING"}}
+
+Errors observed: For existing pd, only ro is supported
+
+The answer is:
+The provided Batch job is trying to mount an existing disk in read-write mode, which is not supported. For existing disks, only read-only mode is supported.
+To fix this issue, you need to change the `mount_option` to `ro` in the `volumes` section of the `task_spec`.
+
+{
+  "allocation_policy": {
+    "instances": [
+      {
+        "policy": {
+          "disks": [
+            {
+              "device_name": "existingpd",
+              "existing_disk": "projects/testingproject/zones/us-central1-c/disks/existingpd"
+            }
+          ]
+        }
+      }
+    ],
+    "location": {
+      "allowed_locations": [
+        "regions/us-central1"
+      ]
+    }
+  },
+  "task_groups":[
+    {
+      "task_spec":{
+        "runnables": [
+          {
+            "script": {
+              "text": "sleep 300"
+            }
+          }
+        ],
+        "volumes": [
+          {
+            "device_name": "batch-e2e-test-existingpd",
+            "mount_path": "/mnt/disks/share",
+            "mount_option": "ro"
+          }
+        ]
+      },
+      "task_count":2
+    }
+  ],
+  "logs_policy": {
+    "destination": "CLOUD_LOGGING"
+  }
+}
+
+
+Example 2:
+
+Batch job to fix is:  {"allocation_policy": {"instances": [{"policy": {"disks": [{"newDisk": {"sizeGb": 30, "type": "pd-standard", "diskInterface": "test"}, "deviceName": "new-pd"}]}}], "location": {"allowed_locations": ["regions/us-central1", "zones/us-central1-c"]}}, "task_groups": [{"task_spec": {"runnables": [{"script": {"text": "sleep 300"}}], "volumes": [{"device_name": "new-pd", "mount_path": "/mnt/share"}]}, "task_count": 2}], "logs_policy": {"destination": "CLOUD_LOGGING"}}
+
+Errors observed: diskInterface can only be NVMe or SCSI.
+
+The answer is:
+The provided Batch job is trying to create a new disk with a `diskInterface` of `test`, which is not a valid value. The `diskInterface` can only be `NVMe` or `SCSI`. To fix this issue, you need to change the `diskInterface` to either `NVMe` or `SCSI` in the `newDisk` section of the `allocation_policy`
+
+{
+  "allocation_policy": {
+    "instances": [
+      {
+        "policy": {
+          "disks": [
+            {
+              "newDisk": {
+                "sizeGb": 30,
+                "type": "pd-standard",
+                "diskInterface": "NVMe"  # Change to either NVMe or SCSI
+              },
+              "deviceName": "new-pd"
+            }
+          ]
+        }
+      }
+    ],
+    "location": {
+      "allowed_locations": [
+        "regions/us-central1",
+        "zones/us-central1-c"
+      ]
+    }
+  },
+  "task_groups": [
+    {
+      "task_spec": {
+        "runnables": [
+          {
+            "script": {
+              "text": "sleep 300"
+            }
+          }
+        ],
+        "volumes": [
+          {
+            "device_name": "new-pd",
+            "mount_path": "/mnt/share"
+          }
+        ]
+      },
+      "task_count": 2
+    }
+  ],
+  "logs_policy": {
+    "destination": "CLOUD_LOGGING"
+  }
+}
+
+Example 3:
+
+Batch job to fix is: {"allocation_policy": {"location": {"allowed_locations": ["regions/us-central1", "zones/us-west1-c"]}}, "task_groups": [{"task_spec": {"runnables": [{"script": {"text": "sleep 300"}}], "volumes": [{"device_name": "new-pd", "mount_path": "/mnt/share"}]}, "task_count": 2}], "logs_policy": {"destination": "CLOUD_LOGGING"}}
+
+Errors observed: all specified locations end up in more than one regions us-central, us-west1
+
+The answer is:
+The provided Batch job specifies multiple locations end up in multiple regions us-central, us-west1, which is not allowed. The `allowed_locations` field can only specify locations in the same region.
+
+{
+  "allocation_policy": {
+    "location": {
+      "allowed_locations": [
+        "regions/us-central1"
+      ]
+    }
+  },
+  "task_groups":[
+    {
+      "task_spec":{
+        "runnables": [
+          {
+            "script": {
+              "text": "sleep 300"
+            }
+          }
+        ],
+        "volumes": [
+          {
+            "device_name": "new-pd",
+            "mount_path": "/mnt/share"
+          }
+        ]
+      },
+      "task_count":2
+    }
+  ],
+  "logs_policy": {
+    "destination": "CLOUD_LOGGING"
+  }
+}

--- a/fixed_job.json
+++ b/fixed_job.json
@@ -1,0 +1,34 @@
+The provided Batch job specifies an invalid Google Cloud location `regions/us-fake`. The `allowed_locations` field must specify valid Google Cloud locations. To fix this issue, you need to change the `allowed_locations` field to specify a valid Google Cloud location.
+
+{
+  "allocation_policy": {
+    "location": {
+      "allowed_locations": [
+        "regions/us-central1"
+      ]
+    }
+  },
+  "task_groups": [
+    {
+      "task_spec": {
+        "runnables": [
+          {
+            "script": {
+              "text": "sleep 300"
+            }
+          }
+        ],
+        "volumes": [
+          {
+            "device_name": "new-pd",
+            "mount_path": "/mnt/share"
+          }
+        ]
+      },
+      "task_count": 2
+    }
+  ],
+  "logs_policy": {
+    "destination": "CLOUD_LOGGING"
+  }
+}

--- a/job_to_fix.json
+++ b/job_to_fix.json
@@ -1,0 +1,32 @@
+{
+  "allocation_policy": {
+    "location": {
+      "allowed_locations": [
+        "regions/us-fake"
+      ]
+    }
+  },
+  "task_groups":[
+    {
+      "task_spec":{
+        "runnables": [
+          {
+            "script": {
+              "text": "sleep 300"
+            }
+          }
+        ],
+        "volumes": [
+          {
+            "device_name": "new-pd",
+            "mount_path": "/mnt/share"
+          }
+        ]
+      },
+      "task_count":2
+    }
+  ],
+  "logs_policy": {
+    "destination": "CLOUD_LOGGING"
+  }
+}


### PR DESCRIPTION
To help customer support by fixing batch jobs
Users offer the job spec they use and errors they observe, this tool can help explain why the batch job fails and offer a right job in JSON format.