### PR TITLE
strip unwanted symbols and json text

### DIFF
--- a/intent2batch.py
+++ b/intent2batch.py
@@ -47,6 +47,8 @@ def multiturn_generate_content():
 
         # Get content from the GenerationResponse
         content = response.candidates[0].content.text
+        content = content.strip('```')
+        content = content.strip('json')
 
         # Show content to user
         print("--------------------------------------------------------------------------------")


### PR DESCRIPTION
Noticed that the generated job config would be in this format sometimes:

```json
{}
```

which is causing the submission failure, adding the code to just strip those away.